### PR TITLE
Exclude sun.jdk:jconsole.

### DIFF
--- a/users-new/pom.xml
+++ b/users-new/pom.xml
@@ -100,6 +100,12 @@
       <artifactId>errai-cdi-jboss</artifactId>
       <version>${version.org.jboss.errai}</version>
       <scope>provided</scope>
+      <exclusions>
+       <exclusion>
+        <artifactId>jconsole</artifactId>
+        <groupId>sun.jdk</groupId>
+       </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR is a workaround/fix for the "Build Failed" message that pops up when you build and deploy in LiveSpark. The `sun.jdk:jconsole` dependency can't be resolved by Guvnor/KIE because it is system-scoped.

Eventually we should have a better fix in Guvnor/KIE that logs warnings for system-scoped dependencies rather than failing the build.
