### PR TITLE
Change users-new version to 1.0-SNAPSHOT.

### DIFF
--- a/users-new/pom.xml
+++ b/users-new/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>demo</groupId>
   <artifactId>users-new</artifactId>
-  <version>1.0</version>
+  <version>1.0-SNAPSHOT</version>
   <name>users-new</name>
   <packaging>war</packaging>
 


### PR DESCRIPTION
The kie-wb-common will fail a deployment if a non-snapshot artifact is installed multiple times.
